### PR TITLE
test: use meta tag content in opengraph image test

### DIFF
--- a/e2e/tests/app/metadata.test.ts
+++ b/e2e/tests/app/metadata.test.ts
@@ -112,18 +112,13 @@ test("should add json+ld metadata", async ({ createIndexPage }) => {
 
 test("should serve an open-graph image", async ({ createIndexPage, request }) => {
 	for (const locale of locales) {
-		const imagePath = `/${locale}/opengraph-image`;
-
 		const { indexPage } = await createIndexPage(locale);
 		await indexPage.goto();
-		await expect(indexPage.page.locator('meta[property="og:image"]')).toHaveAttribute(
-			"content",
-			expect.stringContaining(
-				`${String(createUrl({ baseUrl: env.NEXT_PUBLIC_APP_BASE_URL, pathname: imagePath }))}?`,
-			),
-		);
 
-		const response = await request.get(imagePath);
+		const url = await indexPage.page.locator('meta[property="og:image"]').getAttribute("content");
+		expect(url).toContain(`/${locale}/opengraph-image`);
+
+		const response = await request.get(String(url));
 		const status = response.status();
 		const contentType = response.headers()["content-type"];
 


### PR DESCRIPTION
currently we check if an opengraph image has been generated by simply requesting `/:locale/opengraph-image`.

however, when nested inside a route group, next.js will add a hash to the pathname, e.g. `opengraph-image-123456`, because multiple files could resolve to the same path - think `app/opengraph-image.tsx` and `app/(app)/opengraph-image.tsx`.

this pr fixes the test by retrieving the opengraph image url from the `<meta property="og:image">` element's `content` attribute.