### PR TITLE
chore: lint for string literals in jsx

### DIFF
--- a/app/[locale]/_components/tailwind-indicator.tsx
+++ b/app/[locale]/_components/tailwind-indicator.tsx
@@ -7,14 +7,14 @@ export function TailwindIndicator(): ReactNode {
 
 	return (
 		<div className="fixed bottom-4 right-4 z-10 grid size-8 cursor-default select-none place-content-center rounded-full bg-background-inverse font-mono text-tiny font-strong text-text-inverse-strong shadow-raised">
-			<span className="xs:hidden">2xs</span>
-			<span className="max-xs:hidden sm:hidden">xs</span>
-			<span className="max-sm:hidden md:hidden">sm</span>
-			<span className="max-md:hidden lg:hidden">md</span>
-			<span className="max-lg:hidden xl:hidden">lg</span>
-			<span className="max-xl:hidden 2xl:hidden">xl</span>
-			<span className="max-2xl:hidden 3xl:hidden">2xl</span>
-			<span className="max-3xl:hidden">3xl</span>
+			<span className="xs:hidden">{"2xs"}</span>
+			<span className="max-xs:hidden sm:hidden">{"xs"}</span>
+			<span className="max-sm:hidden md:hidden">{"sm"}</span>
+			<span className="max-md:hidden lg:hidden">{"md"}</span>
+			<span className="max-lg:hidden xl:hidden">{"lg"}</span>
+			<span className="max-xl:hidden 2xl:hidden">{"xl"}</span>
+			<span className="max-2xl:hidden 3xl:hidden">{"2xl"}</span>
+			<span className="max-3xl:hidden">{"3xl"}</span>
 		</div>
 	);
 }


### PR DESCRIPTION
this pr enables a lint rule for jsx-literals. this is useful to flush out any untranslated ui strings.