### PR TITLE
chore: fix types in snippet

### DIFF
--- a/.vscode/app.code-snippets
+++ b/.vscode/app.code-snippets
@@ -76,7 +76,7 @@
 			"",
 			"export async function generateStaticParams(props: {",
 			"\tparams: Pick<${1:Name}PageProps[\"params\"], \"locale\">;",
-			"}): Promise<Awaited<Array<Pick<${1:Name}PageProps[\"params\"], \"id\">>>> {",
+			"}): Promise<Array<Pick<${1:Name}PageProps[\"params\"], \"id\">>> {",
 			"\tconst { params } = props;",
 			"",
 			"\tconst { locale } = params;",


### PR DESCRIPTION
this pr fixes the types in the `next-dynamic-page` vscode snippet.