### PR TITLE
fix: delay closing mobile nav

### DIFF
--- a/app/[locale]/_components/app-navigation.tsx
+++ b/app/[locale]/_components/app-navigation.tsx
@@ -263,7 +263,16 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 																	"aria-[current]:hover-overlay aria-[current]:select-overlay",
 																)}
 																href={item.href}
-																onPress={close}
+																onPress={() => {
+																	/**
+																	 * `next/link` does not support pointer events, and `click`
+																	 * fires after react aria components' `press` events, therefore
+																	 * we delay closing the dialog so the navigation is guaranteed to
+																	 * be triggered. practically, this seems only relevant for
+																	 * firefox on touch devices.
+																	 */
+																	requestAnimationFrame(close);
+																}}
 															>
 																{item.label}
 															</NavLink>
@@ -315,7 +324,16 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 																									"aria-[current]:hover-overlay aria-[current]:select-overlay",
 																								)}
 																								href={item.href}
-																								onPress={close}
+																								onPress={() => {
+																									/**
+																									 * `next/link` does not support pointer events, and `click`
+																									 * fires after react aria components' `press` events, therefore
+																									 * we delay closing the dialog so the navigation is guaranteed to
+																									 * be triggered. practically, this seems only relevant for
+																									 * firefox on touch devices.
+																									 */
+																									requestAnimationFrame(close);
+																								}}
 																							>
 																								{item.label}
 																							</NavLink>


### PR DESCRIPTION
delay closing mobile navigation drawer after link click, to account for different event ordering in firefox with touch events.