### PR TITLE
feat: add types for searchparams

### DIFF
--- a/types/next.d.ts
+++ b/types/next.d.ts
@@ -1,0 +1,1 @@
+type SearchParams = Record<string, string | Array<string>>;


### PR DESCRIPTION
add types for searchparams, making it easier to type unvalidated page params, e.g.

```tsx
export interface SearchPageProps {
  searchParams: SearchParams
}
```