### PR TITLE
refactor: prefer use over usecontext

### DIFF
--- a/components/action-state-context.tsx
+++ b/components/action-state-context.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { assert } from "@acdh-oeaw/lib";
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext, type ReactNode, use } from "react";
 
 import type { ActionState } from "@/lib/server/actions";
 
@@ -17,9 +19,9 @@ export function ActionStateProvider(props: Readonly<ActionStateProviderProps>): 
 }
 
 export function useActionStateContext(): ActionState {
-	const value = useContext(ActionStateContext);
+	const value = use(ActionStateContext);
 
-	assert(value != null);
+	assert(value != null, "`useActionStateContext` must be used within an `ActionStateProvider`.");
 
 	return value;
 }


### PR DESCRIPTION
this pr adapts `use` (introduced in react v19) over `useContext`.