### PR TITLE
test: target navlink container role

### DIFF
--- a/e2e/tests/app/app.test.ts
+++ b/e2e/tests/app/app.test.ts
@@ -159,11 +159,12 @@ test.describe("app", () => {
 			await indexPage.goto();
 
 			const homeLink = indexPage.page
+				.getByRole("navigation")
 				.getByRole("link", {
 					name: i18n.t("AppHeader.links.home"),
 				})
 				.first();
-			const aboutLink = indexPage.page.getByRole("link", {
+			const aboutLink = indexPage.page.getByRole("navigation").getByRole("link", {
 				name: i18n.t("AppHeader.links.about"),
 			});
 
@@ -188,11 +189,12 @@ test.describe("app", () => {
 			await indexPage.page.getByRole("navigation").getByRole("button").click();
 
 			const homeLink = indexPage.page
+				.getByRole("dialog")
 				.getByRole("link", {
 					name: i18n.t("AppHeader.links.home"),
 				})
 				.first();
-			const aboutLink = indexPage.page.getByRole("link", {
+			const aboutLink = indexPage.page.getByRole("dialog").getByRole("link", {
 				name: i18n.t("AppHeader.links.about"),
 			});
 


### PR DESCRIPTION
this pr improves the aria-current e2e test by more specifically targeting links in their containers, i.e. on desktop links should be wrapped in an element with `role="navigation"`, and on mobile in an element with `role="dialog"`.