### PR TITLE
fix: ensure server-image does not set loading=lazy on priority images

### DIFF
--- a/components/server-image.tsx
+++ b/components/server-image.tsx
@@ -21,8 +21,8 @@ export async function ServerImage(props: Readonly<ServerImageProps>): Promise<Re
 		width,
 	} = props;
 
-	const decoding = _decoding ?? (priority ? "auto" : "async");
 	const loading = _loading ?? (priority ? "eager" : "lazy");
+	const decoding = _decoding ?? (priority || loading === "eager" ? "auto" : "async");
 
 	const dimensions =
 		typeof src === "object" || fill === true || (width != null && height != null)

--- a/components/server-image.tsx
+++ b/components/server-image.tsx
@@ -10,7 +10,19 @@ import { getImageDimensions } from "@/lib/server/images/get-image-dimensions";
 interface ServerImageProps extends Omit<NextImageProps, "loader"> {}
 
 export async function ServerImage(props: Readonly<ServerImageProps>): Promise<ReactNode> {
-	const { alt = "", decoding = "async", fill, height, loading = "lazy", src, width } = props;
+	const {
+		alt = "",
+		decoding: _decoding,
+		fill,
+		height,
+		loading: _loading,
+		priority,
+		src,
+		width,
+	} = props;
+
+	const decoding = _decoding ?? (priority ? "auto" : "async");
+	const loading = _loading ?? (priority ? "eager" : "lazy");
 
 	const dimensions =
 		typeof src === "object" || fill === true || (width != null && height != null)
@@ -29,6 +41,7 @@ export async function ServerImage(props: Readonly<ServerImageProps>): Promise<Re
 			decoding={decoding}
 			height={dimensions.height}
 			loading={loading}
+			priority={priority}
 			width={dimensions.width}
 		/>
 	);


### PR DESCRIPTION
this pr ensures that we don't set `loading="lazy"` on images with `priority: true`. it also defaults `decoding` to `auto` on eagerly loaded images.