### PR TITLE
refactor: prefer generate-image-metadata in opengraph image generation

### DIFF
--- a/app/[locale]/opengraph-image.tsx
+++ b/app/[locale]/opengraph-image.tsx
@@ -4,21 +4,30 @@ import { getTranslations } from "next-intl/server";
 import { MetadataImage } from "@/components/metadata-image";
 import type { Locale } from "@/config/i18n.config";
 
+const size = {
+	height: 630,
+	width: 1200,
+};
+
 interface OpenGraphImageProps {
 	params: {
 		locale: Locale;
 	};
 }
 
-// export const alt = ''
-
-export const size = {
-	width: 1200,
-	height: 630,
-};
+export function generateImageMetadata(_props: OpenGraphImageProps) {
+	return [
+		{
+			alt: "",
+			contentType: "image/png",
+			id: "global",
+			size,
+		},
+	];
+}
 
 export default async function OpenGraphImage(
-	props: Readonly<OpenGraphImageProps>,
+	props: Readonly<OpenGraphImageProps & { id: string }>,
 ): Promise<ImageResponse> {
 	const { params } = props;
 


### PR DESCRIPTION
this pr refactors opengraph image generation so it is possible to provide translated alt text.