### PR TITLE
feat: add language utilities

### DIFF
--- a/config/i18n.config.ts
+++ b/config/i18n.config.ts
@@ -48,3 +48,5 @@ export const formats = {
 		},
 	},
 } satisfies Formats;
+
+export type Language = Locale extends `${infer L}-${string}` ? L : Locale;

--- a/lib/i18n/get-language.ts
+++ b/lib/i18n/get-language.ts
@@ -1,0 +1,11 @@
+import { getLocale } from "next-intl/server";
+
+import type { Language } from "@/config/i18n.config";
+
+export async function getLanguage(): Promise<Language> {
+	const locale = await getLocale();
+
+	const language = new Intl.Locale(locale).language as Language;
+
+	return language;
+}

--- a/lib/i18n/use-language.ts
+++ b/lib/i18n/use-language.ts
@@ -1,0 +1,11 @@
+import { useLocale } from "next-intl";
+
+import type { Language } from "@/config/i18n.config";
+
+export function useLanguage(): Language {
+	const locale = useLocale();
+
+	const language = new Intl.Locale(locale).language as Language;
+
+	return language;
+}


### PR DESCRIPTION
this pr adds two utilities to extract the language of a locale. this is in preparation for more explicitly differentiating when we mean "locale" and when we mean "language".