### PR TITLE
feat: enable support for use-cache directive

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,11 @@ const config: NextConfig = {
 		dirs: [process.cwd()],
 		ignoreDuringBuilds: true,
 	},
+	experimental: {
+		// dynamicIO: true,
+		// ppr: true,
+		useCache: true,
+	},
 	headers() {
 		const headers: Awaited<ReturnType<NonNullable<NextConfig["headers"]>>> = [
 			/** @see https://nextjs.org/docs/app/building-your-application/deploying#streaming-and-suspense */


### PR DESCRIPTION
this pr enables support for next-js's `"use cache"` directive. for now, additional support for `dynamicIO` and `ppr` is not yet enabled.

note that this currently requires a next.js canary version to work.