### PR TITLE
feat: add use-cache to imprint page

### DIFF
--- a/app/[locale]/imprint/page.tsx
+++ b/app/[locale]/imprint/page.tsx
@@ -1,3 +1,5 @@
+"use cache";
+
 import { HttpError, request } from "@acdh-oeaw/lib";
 import type { Metadata, ResolvingMetadata } from "next";
 import { notFound } from "next/navigation";


### PR DESCRIPTION
this pr enables `"use cache"` on the imprint page.