### PR TITLE
chore: specify i18n framework for i18n-ally vscode extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
 	},
 	"files.eol": "\n",
 	"i18n-ally.annotations": false,
+	"i18n-ally.enabledFrameworks": ["next-intl"],
 	"i18n-ally.keepFulfilled": true,
 	"i18n-ally.keystyle": "nested",
 	"i18n-ally.localesPaths": ["./messages"],


### PR DESCRIPTION
this pr explicitly specifies `next-intl` as i18n framework in the settings for the i18n-ally vscode extension.