### PR TITLE
chore: add prettier-plugin-tailwindcss

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
 	"i18n-ally.sortKeys": true,
 	"i18n-ally.tabStyle": "tab",
 	"less.validate": false,
+	"prettier.ignorePath": ".gitignore",
 	"scss.validate": false,
 	"stylelint.enable": true,
 	"stylelint.snippet": ["css", "postcss", "tailwindcss"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,6 @@
 	"i18n-ally.sortKeys": true,
 	"i18n-ally.tabStyle": "tab",
 	"less.validate": false,
-	"prettier.ignorePath": ".gitignore",
 	"scss.validate": false,
 	"stylelint.enable": true,
 	"stylelint.snippet": ["css", "postcss", "tailwindcss"],

--- a/app/[locale]/(index)/page.tsx
+++ b/app/[locale]/(index)/page.tsx
@@ -55,13 +55,13 @@ function HeroSection(): ReactNode {
 	const t = useTranslations("IndexPage");
 
 	return (
-		<section className="layout-subgrid relative gap-y-10 bg-fill-weaker py-16 xs:py-24">
-			<div className="max-w-text grid gap-y-6">
+		<section className="relative layout-subgrid gap-y-10 bg-fill-weaker py-16 xs:py-24">
+			<div className="grid max-w-text gap-y-6">
 				<span className="inline-flex items-center gap-x-2 justify-self-start rounded-4 border border-stroke-weak bg-fill-weak px-3 py-0.5 text-tiny text-text-strong">
 					<Logo className="size-5 shrink-0 text-icon-neutral" />
 					<span>{t("badge")}</span>
 				</span>
-				<h1 className="text-balance font-heading text-display font-strong text-text-strong">
+				<h1 className="font-heading text-display font-strong text-balance text-text-strong">
 					{t("title")}
 				</h1>
 				<p className="font-heading text-small text-text-weak xs:text-heading-4">{t("lead-in")}</p>
@@ -84,9 +84,9 @@ function FeaturesSection(): ReactNode {
 
 	/* eslint-disable react/jsx-no-literals */
 	return (
-		<section className="layout-subgrid relative gap-y-12 border-t border-stroke-weak py-16 xs:py-24">
-			<header className="max-w-text grid gap-y-4">
-				<h2 className="text-balance font-heading text-heading-2 font-strong text-text-strong">
+		<section className="relative layout-subgrid gap-y-12 border-t border-stroke-weak py-16 xs:py-24">
+			<header className="grid max-w-text gap-y-4">
+				<h2 className="font-heading text-heading-2 font-strong text-balance text-text-strong">
 					Features
 				</h2>
 				<p className="font-heading text-heading-4 text-text-weak">
@@ -131,7 +131,7 @@ function FeaturesSection(): ReactNode {
 
 			<div>
 				<Link
-					className="focus-visible:focus-outline group inline-flex items-center gap-x-2 rounded-0.5 text-small text-text-brand"
+					className="group inline-flex items-center gap-x-2 rounded-0.5 text-small text-text-brand focus-visible:focus-outline"
 					href="/"
 				>
 					<span className="underline group-hover:no-underline">See all</span>

--- a/app/[locale]/_components/app-footer.tsx
+++ b/app/[locale]/_components/app-footer.tsx
@@ -63,7 +63,7 @@ export function AppFooter(): ReactNode {
 							return (
 								<li key={id} className="shrink-0">
 									<NavLink
-										className="focus-visible:focus-outline inline-block rounded-0.5"
+										className="inline-block rounded-0.5 focus-visible:focus-outline"
 										href={link.href}
 									>
 										<Icon className="size-6 text-icon-neutral transition hover:text-icon-brand" />
@@ -83,7 +83,7 @@ export function AppFooter(): ReactNode {
 							return (
 								<li key={id}>
 									<NavLink
-										className="focus-visible:focus-outline rounded-0.5 hover:underline"
+										className="rounded-0.5 hover:underline focus-visible:focus-outline"
 										href={link.href}
 									>
 										{link.label}
@@ -97,7 +97,7 @@ export function AppFooter(): ReactNode {
 				<small className="text-tiny text-text-weak">
 					&copy; {new Date().getUTCFullYear()}{" "}
 					<a
-						className="focus-visible:focus-outline rounded-0.5 hover:underline"
+						className="rounded-0.5 hover:underline focus-visible:focus-outline"
 						href={meta.social.website}
 					>
 						{t("creator")}

--- a/app/[locale]/_components/app-navigation.tsx
+++ b/app/[locale]/_components/app-navigation.tsx
@@ -77,7 +77,7 @@ export function AppNavigation(props: Readonly<AppNavigationProps>): ReactNode {
 									<NavLink
 										className={cn(
 											"inline-flex px-4 py-6 text-text-strong",
-											"interactive focus-visible:focus-outline hover:hover-overlay pressed:press-overlay",
+											"interactive hover:hover-overlay focus-visible:focus-outline pressed:press-overlay",
 											"aria-[current]:select-overlay-bottom",
 										)}
 										href={item.href}
@@ -120,7 +120,7 @@ export function AppNavigation(props: Readonly<AppNavigationProps>): ReactNode {
 										<Button
 											className={cn(
 												"inline-flex items-center gap-x-2 px-4 py-6 text-text-strong",
-												"interactive focus-visible:focus-outline hover:hover-overlay pressed:press-overlay",
+												"interactive hover:hover-overlay focus-visible:focus-outline pressed:press-overlay",
 											)}
 										>
 											{item.label}
@@ -147,8 +147,8 @@ export function AppNavigation(props: Readonly<AppNavigationProps>): ReactNode {
 																<NavigationMenuItem
 																	key={id}
 																	className={cn(
-																		"flex cursor-pointer select-none items-center gap-x-3 px-4 py-3 text-small text-text-strong",
-																		"interactive focus-visible:focus-outline focus-visible:-focus-outline-offset-2 hover:hover-overlay pressed:press-overlay",
+																		"flex cursor-pointer items-center gap-x-3 px-4 py-3 text-small text-text-strong select-none",
+																		"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay",
 																		"selected:select-overlay-left",
 																	)}
 																	href={item.href}
@@ -230,7 +230,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 				<Button
 					className={cn(
 						"-ml-3 grid place-content-center rounded-2 p-3",
-						"interactive focus-visible:focus-outline focus-visible:focus-outline-offset-0 hover:hover-overlay pressed:press-overlay",
+						"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay",
 					)}
 				>
 					<MenuIcon aria-hidden={true} className="size-6 shrink-0 text-icon-neutral" />
@@ -239,7 +239,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 			</nav>
 			<ModalOverlay
 				className={cn(
-					"fixed left-0 top-0 isolate z-20 h-[var(--visual-viewport-height)] w-full bg-fill-overlay",
+					"fixed top-0 left-0 isolate z-20 h-[var(--visual-viewport-height)] w-full bg-fill-overlay",
 					"entering:duration-200 entering:ease-out entering:animate-in entering:fade-in",
 					"exiting:duration-200 exiting:ease-in exiting:animate-out exiting:fade-out",
 				)}
@@ -263,7 +263,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 										<Button
 											className={cn(
 												"-my-3 -ml-3 grid place-content-center rounded-2 p-3",
-												"interactive focus-visible:focus-outline focus-visible:focus-outline-offset-0 hover:hover-overlay pressed:press-overlay",
+												"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay",
 											)}
 											slot="close"
 										>
@@ -280,8 +280,8 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 															<NavLink
 																className={cn(
 																	"inline-flex w-full px-6 py-3 text-text-strong",
-																	"interactive focus-visible:focus-outline focus-visible:-focus-outline-offset-2 hover:hover-overlay pressed:press-overlay",
-																	"aria-[current]:hover-overlay aria-[current]:select-overlay-left",
+																	"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay",
+																	"aria-[current]:select-overlay-left aria-[current]:hover-overlay",
 																)}
 																href={item.href}
 																onPress={() => {
@@ -321,7 +321,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 																	<Button
 																		className={cn(
 																			"inline-flex w-full items-center justify-between px-6 py-3 text-text-strong",
-																			"interactive focus-visible:focus-outline focus-visible:-focus-outline-offset-2 hover:hover-overlay pressed:press-overlay",
+																			"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay",
 																			"group-expanded:hover-overlay",
 																		)}
 																		slot="trigger"
@@ -343,8 +343,8 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 																							<NavLink
 																								className={cn(
 																									"inline-flex w-full px-6 py-3 text-text-strong",
-																									"interactive focus-visible:focus-outline focus-visible:-focus-outline-offset-2 hover:hover-overlay pressed:press-overlay",
-																									"aria-[current]:hover-overlay aria-[current]:select-overlay-left",
+																									"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay",
+																									"aria-[current]:select-overlay-left aria-[current]:hover-overlay",
 																								)}
 																								href={item.href}
 																								onPress={() => {

--- a/app/[locale]/_components/app-navigation.tsx
+++ b/app/[locale]/_components/app-navigation.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@acdh-oeaw/style-variants";
 import { ChevronDownIcon, ChevronRightIcon, MenuIcon, XIcon } from "lucide-react";
 import { PrefetchKind } from "next/dist/client/components/router-reducer/router-reducer-types";
 import { Fragment, type ReactNode } from "react";
@@ -58,10 +57,7 @@ export function AppNavigation(props: Readonly<AppNavigationProps>): ReactNode {
 	return (
 		<nav aria-label={label} className="hidden md:flex md:gap-x-12">
 			<NavLink
-				className={cn(
-					"-ml-2 grid shrink-0 place-content-center self-center rounded-2 p-2",
-					"interactive focus-visible:focus-outline",
-				)}
+				className="interactive -ml-2 grid shrink-0 place-content-center self-center rounded-2 p-2 focus-visible:focus-outline"
 				href={navigation.home.href}
 			>
 				<Logo className="h-8 w-auto text-text-strong" />
@@ -75,11 +71,7 @@ export function AppNavigation(props: Readonly<AppNavigationProps>): ReactNode {
 							return (
 								<li key={id}>
 									<NavLink
-										className={cn(
-											"inline-flex px-4 py-6 text-text-strong",
-											"interactive hover:hover-overlay focus-visible:focus-outline pressed:press-overlay",
-											"aria-[current]:select-overlay-bottom",
-										)}
+										className="interactive inline-flex px-4 py-6 text-text-strong hover:hover-overlay focus-visible:focus-outline aria-[current]:select-overlay-bottom pressed:press-overlay"
 										href={item.href}
 									>
 										{item.label}
@@ -117,12 +109,7 @@ export function AppNavigation(props: Readonly<AppNavigationProps>): ReactNode {
 							return (
 								<li key={id}>
 									<MenuTrigger>
-										<Button
-											className={cn(
-												"inline-flex items-center gap-x-2 px-4 py-6 text-text-strong",
-												"interactive hover:hover-overlay focus-visible:focus-outline pressed:press-overlay",
-											)}
-										>
+										<Button className="interactive inline-flex items-center gap-x-2 px-4 py-6 text-text-strong hover:hover-overlay focus-visible:focus-outline pressed:press-overlay">
 											{item.label}
 											<ChevronDownIcon
 												aria-hidden={true}
@@ -130,10 +117,7 @@ export function AppNavigation(props: Readonly<AppNavigationProps>): ReactNode {
 											/>
 										</Button>
 										<Popover
-											className={cn(
-												"min-w-[var(--trigger-width)] rounded-2 border border-stroke-weak bg-background-overlay shadow-overlay",
-												"placement-bottom:translate-y-1 placement-bottom:slide-in-from-top-2 entering:animate-in entering:fade-in-0 exiting:animate-out exiting:fade-out-0 exiting:zoom-out-95",
-											)}
+											className="min-w-(--trigger-width) rounded-2 border border-stroke-weak bg-background-overlay shadow-overlay placement-bottom:translate-y-1 placement-bottom:slide-in-from-top-2 entering:animate-in entering:fade-in-0 exiting:animate-out exiting:fade-out-0 exiting:zoom-out-95"
 											placement="bottom"
 										>
 											<Menu
@@ -146,11 +130,7 @@ export function AppNavigation(props: Readonly<AppNavigationProps>): ReactNode {
 															return (
 																<NavigationMenuItem
 																	key={id}
-																	className={cn(
-																		"flex cursor-pointer items-center gap-x-3 px-4 py-3 text-small text-text-strong select-none",
-																		"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay",
-																		"selected:select-overlay-left",
-																	)}
+																	className="interactive flex cursor-pointer items-center gap-x-3 px-4 py-3 text-small text-text-strong select-none hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay selected:select-overlay-left"
 																	href={item.href}
 																	textValue={item.label}
 																>
@@ -227,31 +207,16 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 	return (
 		<DialogTrigger>
 			<nav aria-label={label} className="flex items-center py-3 md:hidden">
-				<Button
-					className={cn(
-						"-ml-3 grid place-content-center rounded-2 p-3",
-						"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay",
-					)}
-				>
+				<Button className="interactive -ml-3 grid place-content-center rounded-2 p-3 hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay">
 					<MenuIcon aria-hidden={true} className="size-6 shrink-0 text-icon-neutral" />
 					<span className="sr-only">{menuOpenLabel}</span>
 				</Button>
 			</nav>
 			<ModalOverlay
-				className={cn(
-					"fixed top-0 left-0 isolate z-20 h-[var(--visual-viewport-height)] w-full bg-fill-overlay",
-					"entering:duration-200 entering:ease-out entering:animate-in entering:fade-in",
-					"exiting:duration-200 exiting:ease-in exiting:animate-out exiting:fade-out",
-				)}
+				className="fixed top-0 left-0 isolate z-20 h-(--visual-viewport-height) w-full bg-fill-overlay entering:duration-200 entering:ease-out entering:animate-in entering:fade-in exiting:duration-200 exiting:ease-in exiting:animate-out exiting:fade-out"
 				isDismissable={true}
 			>
-				<Modal
-					className={cn(
-						"mr-12 size-full max-h-full max-w-sm bg-background-overlay shadow-overlay forced-colors:bg-[Canvas]",
-						"entering:duration-200 entering:ease-out entering:animate-in entering:slide-in-from-left",
-						"exiting:duration-200 exiting:ease-in exiting:animate-out exiting:slide-out-to-left",
-					)}
-				>
+				<Modal className="mr-12 size-full max-h-full max-w-sm bg-background-overlay shadow-overlay forced-colors:bg-[Canvas] entering:duration-200 entering:ease-out entering:animate-in entering:slide-in-from-left exiting:duration-200 exiting:ease-in exiting:animate-out exiting:slide-out-to-left">
 					<Dialog className="relative h-full max-h-[inherit] overflow-auto">
 						{({ close }) => {
 							return (
@@ -261,10 +226,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 											{menuTitleLabel}
 										</Heading>
 										<Button
-											className={cn(
-												"-my-3 -ml-3 grid place-content-center rounded-2 p-3",
-												"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay",
-											)}
+											className="interactive -my-3 -ml-3 grid place-content-center rounded-2 p-3 hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay"
 											slot="close"
 										>
 											<XIcon aria-hidden={true} className="size-6 shrink-0 text-icon-neutral" />
@@ -278,11 +240,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 													return (
 														<li key={id}>
 															<NavLink
-																className={cn(
-																	"inline-flex w-full px-6 py-3 text-text-strong",
-																	"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay",
-																	"aria-[current]:select-overlay-left aria-[current]:hover-overlay",
-																)}
+																className="interactive inline-flex w-full px-6 py-3 text-text-strong hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 aria-[current]:select-overlay-left aria-[current]:hover-overlay pressed:press-overlay"
 																href={item.href}
 																onPress={() => {
 																	/**
@@ -319,11 +277,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 															<Disclosure className="group">
 																<Heading>
 																	<Button
-																		className={cn(
-																			"inline-flex w-full items-center justify-between px-6 py-3 text-text-strong",
-																			"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay",
-																			"group-expanded:hover-overlay",
-																		)}
+																		className="interactive inline-flex w-full items-center justify-between px-6 py-3 text-text-strong group-expanded:hover-overlay hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay"
 																		slot="trigger"
 																	>
 																		{item.label}
@@ -341,11 +295,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 																					return (
 																						<li key={id}>
 																							<NavLink
-																								className={cn(
-																									"inline-flex w-full px-6 py-3 text-text-strong",
-																									"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay",
-																									"aria-[current]:select-overlay-left aria-[current]:hover-overlay",
-																								)}
+																								className="interactive inline-flex w-full px-6 py-3 text-text-strong hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 aria-[current]:select-overlay-left aria-[current]:hover-overlay pressed:press-overlay"
 																								href={item.href}
 																								onPress={() => {
 																									/**

--- a/app/[locale]/_components/color-scheme-select.client.tsx
+++ b/app/[locale]/_components/color-scheme-select.client.tsx
@@ -44,7 +44,7 @@ export function ColorSchemeSelect(props: Readonly<ColorSchemeSelectProps>): Reac
 			<Button
 				className={cn(
 					"grid place-content-center rounded-2 p-3",
-					"interactive focus-visible:focus-outline focus-visible:focus-outline-offset-0 hover:hover-overlay pressed:press-overlay",
+					"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay",
 				)}
 			>
 				<Icon aria-hidden={true} className="size-6 shrink-0 text-icon-neutral" />
@@ -65,8 +65,8 @@ export function ColorSchemeSelect(props: Readonly<ColorSchemeSelectProps>): Reac
 							<ListBoxItem
 								key={id}
 								className={cn(
-									"relative flex cursor-default select-none items-center gap-x-3 px-4 py-3 text-small text-text-strong",
-									"interactive focus-visible:focus-outline focus-visible:-focus-outline-offset-2 hover:hover-overlay pressed:press-overlay selected:hover-overlay selected:select-overlay-left",
+									"relative flex cursor-default items-center gap-x-3 px-4 py-3 text-small text-text-strong select-none",
+									"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay selected:select-overlay-left selected:hover-overlay",
 								)}
 								id={id}
 								textValue={label}

--- a/app/[locale]/_components/color-scheme-select.client.tsx
+++ b/app/[locale]/_components/color-scheme-select.client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@acdh-oeaw/style-variants";
 import { LaptopIcon, MoonIcon, SunIcon } from "lucide-react";
 import type { Key, ReactNode } from "react";
 import { Button, ListBox, ListBoxItem, Popover, Select, SelectValue } from "react-aria-components";
@@ -41,20 +40,12 @@ export function ColorSchemeSelect(props: Readonly<ColorSchemeSelectProps>): Reac
 			onSelectionChange={onSelectionChange}
 			selectedKey={selectedKey}
 		>
-			<Button
-				className={cn(
-					"grid place-content-center rounded-2 p-3",
-					"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay",
-				)}
-			>
+			<Button className="interactive grid place-content-center rounded-2 p-3 hover:hover-overlay focus-visible:focus-outline focus-visible:focus-outline-offset-0 pressed:press-overlay">
 				<Icon aria-hidden={true} className="size-6 shrink-0 text-icon-neutral" />
 				<SelectValue className="sr-only" />
 			</Button>
 			<Popover
-				className={cn(
-					"min-w-[var(--trigger-width)] rounded-2 border border-stroke-weak bg-background-overlay shadow-overlay",
-					"placement-bottom:translate-y-1 placement-bottom:slide-in-from-top-2 entering:animate-in entering:fade-in-0 exiting:animate-out exiting:fade-out-0 exiting:zoom-out-95",
-				)}
+				className="min-w-(--trigger-width) rounded-2 border border-stroke-weak bg-background-overlay shadow-overlay placement-bottom:translate-y-1 placement-bottom:slide-in-from-top-2 entering:animate-in entering:fade-in-0 exiting:animate-out exiting:fade-out-0 exiting:zoom-out-95"
 				placement="bottom"
 			>
 				<ListBox className="max-h-[inherit] min-w-40 overflow-auto py-2">
@@ -64,10 +55,7 @@ export function ColorSchemeSelect(props: Readonly<ColorSchemeSelectProps>): Reac
 						return (
 							<ListBoxItem
 								key={id}
-								className={cn(
-									"relative flex cursor-default items-center gap-x-3 px-4 py-3 text-small text-text-strong select-none",
-									"interactive hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay selected:select-overlay-left selected:hover-overlay",
-								)}
+								className="interactive relative flex cursor-default items-center gap-x-3 px-4 py-3 text-small text-text-strong select-none hover:hover-overlay focus-visible:focus-outline focus-visible:-focus-outline-offset-2 pressed:press-overlay selected:select-overlay-left selected:hover-overlay"
 								id={id}
 								textValue={label}
 							>

--- a/app/[locale]/_components/locale-switcher-link.tsx
+++ b/app/[locale]/_components/locale-switcher-link.tsx
@@ -21,7 +21,7 @@ export function LocaleSwitcherLink(props: Readonly<LocaleSwitcherLinkProps>): Re
 
 	return (
 		<Link
-			className="focus-visible:focus-outline rounded-0.5"
+			className="rounded-0.5 focus-visible:focus-outline"
 			href={createHref({ pathname, searchParams })}
 			locale={locale}
 			replace={true}
@@ -38,7 +38,7 @@ export function LocaleSwitcherLinkFallback(props: Readonly<LocaleSwitcherLinkPro
 
 	return (
 		<Link
-			className="focus-visible:focus-outline rounded-0.5"
+			className="rounded-0.5 focus-visible:focus-outline"
 			href={createHref({ pathname })}
 			locale={locale}
 			replace={true}

--- a/app/[locale]/_components/tailwind-indicator.tsx
+++ b/app/[locale]/_components/tailwind-indicator.tsx
@@ -6,7 +6,7 @@ export function TailwindIndicator(): ReactNode {
 	if (env.NODE_ENV !== "development") return null;
 
 	return (
-		<div className="fixed bottom-4 right-4 z-10 grid size-8 cursor-default select-none place-content-center rounded-full bg-background-inverse font-mono text-tiny font-strong text-text-inverse-strong shadow-raised">
+		<div className="fixed right-4 bottom-4 z-10 grid size-8 cursor-default place-content-center rounded-full bg-background-inverse font-mono text-tiny font-strong text-text-inverse-strong shadow-raised select-none">
 			<span className="xs:hidden">{"2xs"}</span>
 			<span className="max-xs:hidden sm:hidden">{"xs"}</span>
 			<span className="max-sm:hidden md:hidden">{"sm"}</span>

--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -41,9 +41,9 @@ export default async function AboutPage(props: Readonly<AboutPageProps>): Promis
 	/* eslint-disable react/jsx-no-literals */
 	return (
 		<MainContent className="layout-grid content-start">
-			<section className="layout-subgrid relative bg-fill-weaker py-16 xs:py-20">
-				<div className="max-w-text grid gap-y-4">
-					<h1 className="text-balance font-heading text-heading-1 font-strong text-text-strong">
+			<section className="relative layout-subgrid bg-fill-weaker py-16 xs:py-20">
+				<div className="grid max-w-text gap-y-4">
+					<h1 className="font-heading text-heading-1 font-strong text-balance text-text-strong">
 						{t("title")}
 					</h1>
 					<p className="font-heading text-small text-text-weak xs:text-heading-4">
@@ -54,7 +54,7 @@ export default async function AboutPage(props: Readonly<AboutPageProps>): Promis
 				</div>
 			</section>
 
-			<section className="layout-subgrid typography content-max-w-text relative border-t border-stroke-weak py-16 xs:py-20">
+			<section className="relative layout-subgrid typography content-max-w-text border-t border-stroke-weak py-16 xs:py-20">
 				<h2>Lorem Ipsum Dolor Sit Amet</h2>
 				<p>
 					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vehicula metus nec erat

--- a/app/[locale]/imprint/page.tsx
+++ b/app/[locale]/imprint/page.tsx
@@ -44,9 +44,9 @@ export default async function ImprintPage(props: Readonly<ImprintPageProps>): Pr
 
 	return (
 		<MainContent className="layout-grid content-start">
-			<section className="layout-subgrid relative grid gap-y-6 bg-fill-weaker py-16 xs:py-20">
-				<div className="max-w-text grid gap-y-4">
-					<h1 className="text-balance font-heading text-heading-1 font-strong text-text-strong">
+			<section className="relative layout-subgrid grid gap-y-6 bg-fill-weaker py-16 xs:py-20">
+				<div className="grid max-w-text gap-y-4">
+					<h1 className="font-heading text-heading-1 font-strong text-balance text-text-strong">
 						{t("title")}
 					</h1>
 				</div>
@@ -54,7 +54,7 @@ export default async function ImprintPage(props: Readonly<ImprintPageProps>): Pr
 
 			<section
 				dangerouslySetInnerHTML={{ __html: html }}
-				className="layout-subgrid content-max-w-text typography relative border-t border-stroke-weak py-16 xs:py-20"
+				className="relative layout-subgrid typography content-max-w-text border-t border-stroke-weak py-16 xs:py-20"
 			/>
 		</MainContent>
 	);

--- a/app/[locale]/internal-error.tsx
+++ b/app/[locale]/internal-error.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@acdh-oeaw/style-variants";
 import { useTranslations } from "next-intl";
 import { type ReactNode, useEffect, useTransition } from "react";
 import { Button } from "react-aria-components";
@@ -34,10 +33,7 @@ export default function InternalError(props: Readonly<InternalErrorProps>): Reac
 					{t("something-went-wrong")}
 				</h1>
 				<Button
-					className={cn(
-						"inline-flex min-h-8 items-center rounded-2 border border-stroke-brand-strong bg-fill-brand-strong px-3 py-1 text-tiny font-strong text-text-inverse-strong shadow-raised",
-						"interactive hover:hover-overlay focus-visible:focus-outline pressed:press-overlay",
-					)}
+					className="interactive inline-flex min-h-8 items-center rounded-2 border border-stroke-brand-strong bg-fill-brand-strong px-3 py-1 text-tiny font-strong text-text-inverse-strong shadow-raised hover:hover-overlay focus-visible:focus-outline pressed:press-overlay"
 					isPending={isPending}
 					onPress={() => {
 						startTransition(() => {

--- a/app/[locale]/internal-error.tsx
+++ b/app/[locale]/internal-error.tsx
@@ -30,13 +30,13 @@ export default function InternalError(props: Readonly<InternalErrorProps>): Reac
 	return (
 		<MainContent className="layout-grid bg-fill-weaker">
 			<section className="grid place-content-center place-items-center gap-y-8 py-16 xs:py-24">
-				<h1 className="text-balance text-center font-heading text-display font-strong text-text-strong">
+				<h1 className="text-center font-heading text-display font-strong text-balance text-text-strong">
 					{t("something-went-wrong")}
 				</h1>
 				<Button
 					className={cn(
 						"inline-flex min-h-8 items-center rounded-2 border border-stroke-brand-strong bg-fill-brand-strong px-3 py-1 text-tiny font-strong text-text-inverse-strong shadow-raised",
-						"interactive focus-visible:focus-outline hover:hover-overlay pressed:press-overlay",
+						"interactive hover:hover-overlay focus-visible:focus-outline pressed:press-overlay",
 					)}
 					isPending={isPending}
 					onPress={() => {

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -42,7 +42,7 @@ export default function NotFoundPage(_props: Readonly<NotFoundPageProps>): React
 	return (
 		<MainContent className="layout-grid bg-fill-weaker">
 			<section className="grid place-content-center place-items-center py-16 xs:py-24">
-				<h1 className="text-balance text-center font-heading text-display font-strong text-text-strong">
+				<h1 className="text-center font-heading text-display font-strong text-balance text-text-strong">
 					{t("title")}
 				</h1>
 			</section>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -51,7 +51,7 @@ export default async function NotFoundPage(): Promise<ReactNode> {
 
 				<MainContent className="layout-grid min-h-full bg-fill-weaker">
 					<section className="grid place-content-center place-items-center py-16 xs:py-24">
-						<h1 className="text-balance text-center font-heading text-display font-strong text-text-strong">
+						<h1 className="text-center font-heading text-display font-strong text-balance text-text-strong">
 							{t("title")}
 						</h1>
 					</section>

--- a/components/main-content.tsx
+++ b/components/main-content.tsx
@@ -12,7 +12,7 @@ export function MainContent(props: Readonly<MainContentProps>): ReactNode {
 	const { children, className } = props;
 
 	return (
-		<main className={cn("outline-none", className)} id={id} tabIndex={-1}>
+		<main className={cn("outline-hidden", className)} id={id} tabIndex={-1}>
 			{children}
 		</main>
 	);

--- a/components/skip-link.tsx
+++ b/components/skip-link.tsx
@@ -23,7 +23,7 @@ export function SkipLink(props: Readonly<SkipLinkProps>): ReactNode {
 
 	return (
 		<Link
-			className="focus-visible:focus-outline fixed z-50 m-1 translate-y-[calc(-100%-0.25rem)] rounded bg-background-inverse px-4 py-3 text-text-inverse-strong transition focus-visible:translate-y-0"
+			className="fixed z-50 m-1 translate-y-[calc(-100%-0.25rem)] rounded bg-background-inverse px-4 py-3 text-text-inverse-strong transition focus-visible:translate-y-0 focus-visible:focus-outline"
 			href={createHref({ hash: targetId })}
 			id={id}
 			onPress={onPress}

--- a/components/toast-region.tsx
+++ b/components/toast-region.tsx
@@ -8,7 +8,7 @@ import { queue, Toast } from "@/components/toast";
 export function ToastRegion(): ReactNode {
 	return (
 		<AriaToastRegion
-			className="fixed bottom-4 right-4 flex flex-col gap-2 outline-hidden rounded-2 focus-visible:focus-outline"
+			className="fixed right-4 bottom-4 flex flex-col gap-2 rounded-2 outline-hidden focus-visible:focus-outline"
 			queue={queue}
 		>
 			{({ toast }) => {

--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -40,7 +40,7 @@ export function Toast(props: ToastProps): ReactNode {
 	return (
 		<AriaToast
 			{...props}
-			className="flex items-center gap-x-6 bg-fill-brand-strong text-text-inverse-strong shadow-overlay rounded-2 px-6 py-4 focus-visible:focus-outline"
+			className="flex items-center gap-x-6 rounded-2 bg-fill-brand-strong px-6 py-4 text-text-inverse-strong shadow-overlay focus-visible:focus-outline"
 			style={{
 				// @ts-expect-error @see https://developer.chrome.com/blog/view-transitions-update-io24#view-transition-class
 				viewTransitionClass: "toast",
@@ -48,8 +48,8 @@ export function Toast(props: ToastProps): ReactNode {
 			}}
 			toast={toast}
 		>
-			<AriaToastContent className="grid gap-y-1 flex-1 min-w-0">
-				<AriaText className="text-small text-text-inverse-strong font-strong" slot="title">
+			<AriaToastContent className="grid min-w-0 flex-1 gap-y-1">
+				<AriaText className="text-small font-strong text-text-inverse-strong" slot="title">
 					{toast.content.title}
 				</AriaText>
 				<AriaText className="text-small text-text-inverse-weak empty:hidden" slot="description">
@@ -57,7 +57,7 @@ export function Toast(props: ToastProps): ReactNode {
 				</AriaText>
 			</AriaToastContent>
 			<AriaButton
-				className="rounded-full text-icon-inverse inline-grid place-content-center shrink-0 interactive hover:hover-overlay pressed:press-overlay focus-visible:focus-outline"
+				className="interactive inline-grid shrink-0 place-content-center rounded-full text-icon-inverse hover:hover-overlay focus-visible:focus-outline pressed:press-overlay"
 				slot="close"
 			>
 				<XIcon aria-hidden={true} className="size-6 shrink-0" />

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"lucide-react": "^0.476.0",
 		"next": "canary",
 		"next-intl": "v4-beta",
+		"prettier-plugin-tailwindcss": "^0.6.11",
 		"react": "^19.0.0",
 		"react-aria": "nightly",
 		"react-aria-components": "nightly",
@@ -134,7 +135,6 @@
 			"@tailwindcss/postcss": {}
 		}
 	},
-	"prettier": "@acdh-oeaw/prettier-config",
 	"simple-git-hooks": {
 		"pre-commit": "pnpm exec lint-staged"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       next-intl:
         specifier: v4-beta
         version: 4.0.0-beta-dea867b(next@15.2.1-canary.0(@babel/core@7.26.9)(@playwright/test@1.50.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.11
+        version: 0.6.11(prettier@3.5.2)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -2150,8 +2153,8 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  eslint-plugin-react-compiler@19.0.0-beta-e1e972c-20250221:
-    resolution: {integrity: sha512-qdkOo4TJqFfK5td7EVNxDG2zAY44qK+ew7GKZ+nybOS/ONHFVRnluMfC+yjqyBexlfDZJul5ZFzsANJDQa3WSw==}
+  eslint-plugin-react-compiler@19.0.0-beta-40c6c23-20250301:
+    resolution: {integrity: sha512-9K59D9imZCdgdbA5OIa4EL1rCoNAmHNDGYW8sI8gYM0ILAb+foIR+3tpv6y0L/KHz1Mbhyx0KqVBq4lSG/5ykQ==}
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
     peerDependencies:
       eslint: '>=7'
@@ -3175,6 +3178,61 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-plugin-tailwindcss@0.6.11:
+    resolution: {integrity: sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
   prettier@3.5.2:
     resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
     engines: {node: '>=14'}
@@ -3772,7 +3830,7 @@ snapshots:
       eslint-config-prettier: 10.0.2(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.4(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-react-compiler: 19.0.0-beta-e1e972c-20250221(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-react-compiler: 19.0.0-beta-40c6c23-20250301(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.21.0(jiti@2.4.2))
     transitivePeerDependencies:
       - eslint
@@ -6284,7 +6342,7 @@ snapshots:
       eslint: 9.21.0(jiti@2.4.2)
       globals: 13.24.0
 
-  eslint-plugin-react-compiler@19.0.0-beta-e1e972c-20250221(eslint@9.21.0(jiti@2.4.2)):
+  eslint-plugin-react-compiler@19.0.0-beta-40c6c23-20250301(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       '@babel/core': 7.26.9
       '@babel/parser': 7.26.9
@@ -7375,6 +7433,10 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-tailwindcss@0.6.11(prettier@3.5.2):
+    dependencies:
+      prettier: 3.5.2
 
   prettier@3.5.2: {}
 

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,13 @@
+/** @typedef {import("prettier").Config} Config */
+
+import preset from "@acdh-oeaw/prettier-config";
+
+/** @type {Config} */
+const config = {
+	...preset,
+	plugins: [...(preset.plugins ?? []), "prettier-plugin-tailwindcss"],
+	tailwindFunctions: ["cn", "styles"],
+	tailwindStylesheet: "./styles/index.css",
+};
+
+export default config;

--- a/styles/base.css
+++ b/styles/base.css
@@ -22,7 +22,7 @@
 	}
 
 	:focus-visible {
-		@apply outline-2 outline-stroke-focus outline-offset-2;
+		@apply outline-2 outline-offset-2 outline-stroke-focus;
 	}
 
 	/** Let react aria components handle focus state. */

--- a/styles/interactions.css
+++ b/styles/interactions.css
@@ -1,6 +1,6 @@
 @utility focus-outline {
 	/** Interaction states. */
-	@apply outline-2 outline-stroke-focus outline-offset-2;
+	@apply outline-2 outline-offset-2 outline-stroke-focus;
 }
 
 @utility focus-outline-offset-0 {
@@ -20,11 +20,11 @@
 }
 
 @utility select-overlay-left {
-	@apply after:border-stroke-selected after:border-l-4;
+	@apply after:border-l-4 after:border-stroke-selected;
 }
 
 @utility select-overlay-bottom {
-	@apply after:border-stroke-selected after:border-b-4;
+	@apply after:border-b-4 after:border-stroke-selected;
 }
 
 @utility press-overlay {
@@ -32,5 +32,5 @@
 }
 
 @utility target-area {
-	@apply before:absolute before:min-w-[48px] before:min-h-[48px] before:top-1/2 before:left-1/2 before:-translate-x-1/2 before:-translate-y-1/2;
+	@apply before:absolute before:top-1/2 before:left-1/2 before:min-h-[48px] before:min-w-[48px] before:-translate-x-1/2 before:-translate-y-1/2;
 }


### PR DESCRIPTION
this pr
- enables `prettier-plugin-tailwindcss` as a temporary solution for class name sorting, until `eslint-plugin-tailwindcss` lands support for tailwindcss v4
- removes some unnecessary `cn()` calls and updates tailwind arbitrary value syntax for css custom properties
- for now we also keep the `prettier.ignorePath: ".gitignore"` vscode setting, because even though prettier v3 automatically ignores files from gitignore, the vscode prettier extension does *not* yet do that