### PR TITLE
chore: avoid vscode import suggestions for icons without icon suffix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,7 @@
 	"typescript.enablePromptUseWorkspaceTsdk": true,
 	"typescript.inlayHints.parameterNames.enabled": "all",
 	"typescript.preferences.autoImportFileExcludePatterns": [
+		"lucide-react",
 		"next/router.d.ts",
 		"next/dist/client/router.d.ts"
 	],

--- a/types/icons.d.ts
+++ b/types/icons.d.ts
@@ -1,0 +1,4 @@
+/** @see https://github.com/lucide-icons/lucide/pull/2328 */
+declare module "lucide-react" {
+	export * from "lucide-react/dist/lucide-react.suffixed";
+}


### PR DESCRIPTION
lucide icons provide icon exports as both `Section`, `SectionIcon`, and `LucideSection`. we want to avoid polluting the import space for vscode auto-import suggestions, especially with generic component names which don't make clear that they are icons (e.g. `Section`).

this pr uses typescript module augmentation to ensure that only components suffixes with `Icon` - e.g. `SectionIcon` - appear as lucide auto-import suggestions in vscode.