### PR TITLE
fix: patch next/image .svg types

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,10 @@
 			"esbuild",
 			"sharp",
 			"simple-git-hooks"
-		]
+		],
+		"patchedDependencies": {
+			"next": "patches/next.patch"
+		}
 	},
 	"browserslist": {
 		"development": [

--- a/patches/next.patch
+++ b/patches/next.patch
@@ -1,0 +1,18 @@
+diff --git a/image-types/global.d.ts b/image-types/global.d.ts
+index 661c316e89b3c1aa5913b8afebdbf3e6299eccd7..3a749f8e1d0b1b6f454d1f8695b3ae8dbd1934ac 100644
+--- a/image-types/global.d.ts
++++ b/image-types/global.d.ts
+@@ -8,12 +8,7 @@ declare module '*.png' {
+ }
+ 
+ declare module '*.svg' {
+-  /**
+-   * Use `any` to avoid conflicts with
+-   * `@svgr/webpack` plugin or
+-   * `babel-plugin-inline-react-svg` plugin.
+-   */
+-  const content: any
++  const content: import('../dist/shared/lib/image-external').StaticImageData
+ 
+   export default content
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  next:
+    hash: de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624
+    path: patches/next.patch
+
 importers:
 
   .:
@@ -34,10 +39,10 @@ importers:
         version: 0.479.0(react@19.0.0)
       next:
         specifier: canary
-        version: 15.2.2-canary.4(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.2.2-canary.4(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next-intl:
         specifier: v4-beta
-        version: 4.0.0-beta-dea867b(next@15.2.2-canary.4(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(typescript@5.8.2)
+        version: 4.0.0-beta-dea867b(next@15.2.2-canary.4(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(typescript@5.8.2)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -7198,17 +7203,17 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-intl@4.0.0-beta-dea867b(next@15.2.2-canary.4(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(typescript@5.8.2):
+  next-intl@4.0.0-beta-dea867b(next@15.2.2-canary.4(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(typescript@5.8.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       negotiator: 1.0.0
-      next: 15.2.2-canary.4(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.2.2-canary.4(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       use-intl: 4.0.0-beta-dea867b(react@19.0.0)
     optionalDependencies:
       typescript: 5.8.2
 
-  next@15.2.2-canary.4(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.2.2-canary.4(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.26.9)(@playwright/test@1.51.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.2.2-canary.4
       '@swc/counter': 0.1.3

--- a/types/image.d.ts
+++ b/types/image.d.ts
@@ -1,8 +1,0 @@
-declare module "*.svg" {
-	// eslint-disable-next-line no-restricted-imports
-	import type { StaticImageData } from "next/image";
-
-	const content: StaticImageData;
-
-	export default content;
-}


### PR DESCRIPTION
this pr patches the `next/image` type declarations for `.svg` imports, which default to `any`. also removes the previous attempt to override types via our own `image.d.ts` which did not work.