### PR TITLE
refactor: separate providers

### DIFF
--- a/app/[locale]/_components/aria-providers.tsx
+++ b/app/[locale]/_components/aria-providers.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+	I18nProvider as AriaI18nProvider,
+	RouterProvider as AriaRouterProvider,
+} from "react-aria-components";
+
+import type { IntlLocale } from "@/lib/i18n/locales";
+import { useRouter } from "@/lib/navigation/navigation";
+
+interface AriaProvidersProps {
+	children: ReactNode;
+	locale: IntlLocale;
+}
+
+export function AriaProviders(props: Readonly<AriaProvidersProps>): ReactNode {
+	const { children, locale } = props;
+
+	const router = useRouter();
+
+	return (
+		<AriaI18nProvider locale={locale}>
+			<AriaRouterProvider navigate={router.push}>{children}</AriaRouterProvider>
+		</AriaI18nProvider>
+	);
+}

--- a/app/[locale]/_components/providers.tsx
+++ b/app/[locale]/_components/providers.tsx
@@ -1,12 +1,9 @@
-"use client";
-
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
-import { I18nProvider as RacI18nProvider, RouterProvider } from "react-aria-components";
 
+import { AriaProviders } from "@/app/[locale]/_components/aria-providers";
 import type { IntlLocale } from "@/lib/i18n/locales";
 import type { IntlMessages } from "@/lib/i18n/messages";
-import { useRouter } from "@/lib/navigation/navigation";
 
 interface ProvidersProps {
 	children: ReactNode;
@@ -19,21 +16,7 @@ export function Providers(props: Readonly<ProvidersProps>): ReactNode {
 
 	return (
 		<NextIntlClientProvider locale={locale} messages={messages}>
-			<RacI18nProvider locale={locale}>
-				<RacRouterProvider>{children}</RacRouterProvider>
-			</RacI18nProvider>
+			<AriaProviders locale={locale}>{children}</AriaProviders>
 		</NextIntlClientProvider>
 	);
-}
-
-interface RacRouterProviderProps {
-	children: ReactNode;
-}
-
-function RacRouterProvider(props: Readonly<RacRouterProviderProps>): ReactNode {
-	const { children } = props;
-
-	const router = useRouter();
-
-	return <RouterProvider navigate={router.push}>{children}</RouterProvider>;
 }

--- a/lib/i18n/locales.ts
+++ b/lib/i18n/locales.ts
@@ -1,4 +1,4 @@
-import { hasLocale } from "next-intl";
+import { hasLocale, type Timezone } from "next-intl";
 
 export const locales = ["de-AT", "en-GB"] as const;
 
@@ -19,3 +19,5 @@ export type IntlLanguage = IntlLocale extends `${infer Language}-${string}` ? La
 export function getIntlLanguage(locale: IntlLocale): IntlLanguage {
 	return createIntlLocale(locale).language as IntlLanguage;
 }
+
+export const timeZone: Timezone = "UTC";

--- a/lib/i18n/request.ts
+++ b/lib/i18n/request.ts
@@ -2,6 +2,7 @@ import { hasLocale } from "next-intl";
 import { getRequestConfig } from "next-intl/server";
 
 import { formats } from "@/lib/i18n/formats";
+import { timeZone } from "@/lib/i18n/locales";
 import { getIntlMessages } from "@/lib/i18n/messages";
 import { routing } from "@/lib/i18n/routing";
 
@@ -11,7 +12,6 @@ export default getRequestConfig(async ({ requestLocale }) => {
 		? requestedLocale
 		: routing.defaultLocale;
 	const messages = await getIntlMessages(locale);
-	const timeZone = "UTC";
 
 	return {
 		formats,


### PR DESCRIPTION
this pr moves client-only providers to a separate module, so `NextIntlClientProvider` is rendered in a server component, which is required for it to correctly inherit `timeZone` and `now` config.