### PR TITLE
fix: use loading indicator for pending button state

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -120,7 +120,7 @@ export function Button(props: Readonly<ButtonProps>): ReactNode {
 
 				return (
 					<Fragment>
-						{isPending ? <LoadingIndicator data-slot="icon" /> : null}
+						{isPending ? <LoadingIndicator data-slot="icon" delay="none" /> : null}
 						{children}
 					</Fragment>
 				);


### PR DESCRIPTION
this pr uses the `LoadingIndicator` component for buttons in "pending" state.

TODO:

- [ ] currently, displaying the spinner is delayed for 500ms via css animation, but it still takes up space in the dom and this stretches the button, which looks weird. we should delay rendering the spinner so it is only displayed as button content after 500ms. alternatively, delay mounting the spinner with `setTimeout`, cf. #73

probably better to (i) fade/slide-out the button text, and (ii) fade/slide-in the spinner to avoid layout shift