### PR TITLE
refactor: replace fast-glob with node builtin glob

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
+import { glob } from "node:fs/promises";
 import { join } from "node:path";
 
 import { createUrl } from "@acdh-oeaw/lib";
-import { glob } from "fast-glob";
 import type { MetadataRoute } from "next";
 
 import { env } from "@/config/env.config";
@@ -18,29 +18,35 @@ const baseUrl = env.NEXT_PUBLIC_APP_BASE_URL;
  * @see https://nextjs.org/docs/app/api-reference/functions/generate-sitemaps
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-	const paths = await glob("./**/page.tsx", { cwd: join(process.cwd(), "app", "[locale]") });
-
 	const routes: Array<string> = [];
 
-	paths.forEach((path) => {
+	for await (const path of glob("./**/page.tsx", {
+		cwd: join(process.cwd(), "app", "[locale]"),
+		exclude: [
+			/** Catch-all route for i18n not-found. */
+			"[...segments]",
+		],
+	})) {
 		const route = path.slice(0, -"/page.tsx".length);
-
-		if (route === "[...segments]") return;
 
 		const segments = [];
 
 		for (const segment of route.split("/")) {
 			/** Dynamic routes. */
-			if (segment.startsWith("[") && segment.endsWith("]")) return;
+			if (segment.startsWith("[") && segment.endsWith("]")) {
+				break;
+			}
 
 			/** Route groups. */
-			if (segment.startsWith("(") && segment.endsWith(")")) continue;
+			if (segment.startsWith("(") && segment.endsWith(")")) {
+				continue;
+			}
 
 			segments.push(segment);
 		}
 
 		routes.push(`/${segments.join("/")}`);
-	});
+	}
 
 	const entries = locales.flatMap((locale) => {
 		return routes.map((pathname) => {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"@react-aria/utils": "^3.29.0",
 		"@valibot/i18n": "^1.0.0",
 		"client-only": "^0.0.1",
-		"fast-glob": "^3.3.3",
 		"image-dimensions": "^2.3.0",
 		"lucide-react": "^0.511.0",
 		"next": "canary",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,9 +31,6 @@ importers:
       client-only:
         specifier: ^0.0.1
         version: 0.0.1
-      fast-glob:
-        specifier: ^3.3.3
-        version: 3.3.3
       image-dimensions:
         specifier: ^2.3.0
         version: 2.3.0


### PR DESCRIPTION
this replaces `fast-glob` with node's built-in `glob`, which is still marked as experimental in node v22, but stable in v24.