### PR TITLE
chore: remove unused i18n strings

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -76,7 +76,6 @@
 	},
 	"LocaleSwitcher": {
 		"current-locale": "Aktuelle Sprache: {locale}",
-		"switch-locale": "Sprache wechseln",
 		"switch-locale-to": "Zu {locale} wechseln"
 	},
 	"NotFoundPage": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -76,7 +76,6 @@
 	},
 	"LocaleSwitcher": {
 		"current-locale": "Current language: {locale}",
-		"switch-locale": "Switch locale",
 		"switch-locale-to": "Switch to {locale}"
 	},
 	"NotFoundPage": {


### PR DESCRIPTION
this pr removes unused translations, which were discovered by running `pnpm i18n:check`.