### PR TITLE
fix: remove workaround for next/link pointer events

### DIFF
--- a/app/[locale]/_components/app-navigation.tsx
+++ b/app/[locale]/_components/app-navigation.tsx
@@ -197,20 +197,7 @@ export function AppNavigationMobile(props: Readonly<AppNavigationMobileProps>): 
 			<ModalOverlay isDismissable={true}>
 				<Modal placement="left">
 					<Drawer>
-						{({ close: _close }) => {
-							function close() {
-								/**
-								 * `next/link` does not support pointer events, and `click`
-								 * fires after react aria components' `press` events, therefore
-								 * we delay closing the dialog so the navigation is guaranteed to
-								 * be triggered. practically, this seems only relevant for
-								 * firefox on touch devices.
-								 *
-								 * maybe unnecessary after @see https://github.com/adobe/react-spectrum/pull/7542
-								 */
-								requestAnimationFrame(_close);
-							}
-
+						{({ close }) => {
 							return (
 								<Fragment>
 									<header className="p-6">


### PR DESCRIPTION
should no longer be necessary in current version of react-aria-components.