### PR TITLE
fix: rename font-mono to font-code

### DIFF
--- a/app/[locale]/_components/tailwind-indicator.tsx
+++ b/app/[locale]/_components/tailwind-indicator.tsx
@@ -6,7 +6,7 @@ export function TailwindIndicator(): ReactNode {
 	if (env.NODE_ENV !== "development") return null;
 
 	return (
-		<div className="fixed right-5 bottom-5 z-10 grid size-9 cursor-default place-content-center rounded-full bg-background-inverse font-mono text-tiny font-strong text-text-inverse-strong shadow-raised select-none">
+		<div className="fixed right-5 bottom-5 z-10 grid size-9 cursor-default place-content-center rounded-full bg-background-inverse font-code text-tiny font-strong text-text-inverse-strong shadow-raised select-none">
 			<span className="xs:hidden">{"2xs"}</span>
 			<span className="max-xs:hidden sm:hidden">{"xs"}</span>
 			<span className="max-sm:hidden md:hidden">{"sm"}</span>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -101,7 +101,7 @@ export default async function LocaleLayout(props: Readonly<LocaleLayoutProps>): 
 			className={cn(
 				fonts.body.variable,
 				fonts.heading.variable,
-				fonts.mono.variable,
+				fonts.code.variable,
 				"bg-background-base text-text-strong antialiased",
 			)}
 			lang={locale}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -37,7 +37,7 @@ export default async function NotFoundPage(): Promise<ReactNode> {
 			className={cn(
 				fonts.body.variable,
 				fonts.heading.variable,
-				fonts.mono.variable,
+				fonts.code.variable,
 				"bg-background-base text-text-strong antialiased",
 			)}
 			lang={defaultLocale}

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -16,9 +16,9 @@ export const heading = Inter({
 	variable: "--_font-heading",
 });
 
-export const mono = Fira_Code({
+export const code = Fira_Code({
 	display: "swap",
 	preload: false,
 	subsets: ["latin", "latin-ext"],
-	variable: "--_font-mono",
+	variable: "--_font-code",
 });

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -1,5 +1,5 @@
 @utility alignment-grid {
-	--alignment-color: var(--color-neutral-200);
+	--alignment-color: var(--color-stroke-weak);
 
 	background-image:
 		linear-gradient(to right, var(--alignment-color) 1px, transparent 1px),

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -389,7 +389,7 @@
 
 	--font-body: var(--_font-body, var(--font-sans));
 	--font-heading: var(--_font-heading, var(--font-body));
-	--font-mono: var(--_font-mono, var(--font-mono));
+	--font-code: var(--_font-code, var(--font-mono));
 }
 
 /** Font size tokens. */

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -126,7 +126,7 @@
 		color: var(--color-typography-strong);
 		font-weight: var(--font-weight-strong);
 		font-size: var(--text-tiny);
-		font-family: var(--font-mono);
+		font-family: var(--font-code);
 	}
 
 	& :where(pre) {
@@ -139,7 +139,7 @@
 		color: var(--color-text-inverse-strong);
 		font-weight: var(--font-weight-weak);
 		font-size: var(--text-tiny);
-		font-family: var(--font-mono);
+		font-family: var(--font-code);
 		line-height: var(--text-small--line-height);
 	}
 


### PR DESCRIPTION
this renames `--font-mono` to `--font-code` to avoid clashing with tailwind's built-in `font-mono`.