### PR TITLE
build: pin pnpm to 10.12 to work around pnpm fetch issues in docker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"node": "22.x",
 		"pnpm": "10.x"
 	},
-	"packageManager": "pnpm@10.13.1",
+	"packageManager": "pnpm@10.12.1",
 	"scripts": {
 		"analyze": "BUNDLE_ANALYZER=\"enabled\" next build --no-lint",
 		"build": "next build",


### PR DESCRIPTION
this pins the pnpm version because 10.13.1 has an issue with `pnpm fetch` in docker build or ci. 