### PR TITLE
chore: pin pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"node": "22.x",
 		"pnpm": "10.x"
 	},
-	"packageManager": "pnpm@10.12.4",
+	"packageManager": "pnpm@10.12.3",
 	"scripts": {
 		"analyze": "BUNDLE_ANALYZER=\"enabled\" next build --no-lint",
 		"build": "next build",


### PR DESCRIPTION
trying to figure out which pnpm version exactly has introduced an issue in docker build context. last known good version: 10.12.1, first known bad version: 10.12.4.